### PR TITLE
Avoid running celestial::cosdisLumDist() if LumDist is supplied

### DIFF
--- a/R/photom.R
+++ b/R/photom.R
@@ -59,10 +59,12 @@ Janskycalc=function(wave, flux, filter='r_VST'){
 }
 
 
-Lum2FluxFactor=function(z = 0.1, H0 = 67.8, OmegaM = 0.308, OmegaL = 1 - OmegaM, ref){
+Lum2FluxFactor=function(z = 0.1, H0 = 67.8, OmegaM = 0.308, OmegaL = 1 - OmegaM, ref, Dl_cm=NULL){
   # Assuming lum to be converted is in the BC03 Lsol / Angstrom format
   # Because AB system is explicitly erg/s/cm^2/Hz flux
-  Dl_cm=cosdistLumDist(z=z, H0 = H0, OmegaM = OmegaM, OmegaL = OmegaL, ref=ref)*.mpc_to_cm
+  if(is.null(Dl_cm)){
+    Dl_cm=cosdistLumDist(z=z, H0 = H0, OmegaM = OmegaM, OmegaL = OmegaL, ref=ref)*.mpc_to_cm
+  }
   factor=.lsol_to_erg/(4*pi*Dl_cm^2)/(1+z)
   return(factor)
 }
@@ -84,7 +86,7 @@ Lum2Flux=function(wave, lum, z = 0.1, H0 = 67.8, OmegaM = 0.308, OmegaL = 1 - Om
   return(data.frame(wave=wave, flux=flux))
 }
 
-Flux2Lum=function(wave, flux, z = 0.1, H0 = 67.8, OmegaM = 0.308, OmegaL = 1 - OmegaM, ref){
+Flux2Lum=function(wave, flux, z = 0.1, H0 = 67.8, OmegaM = 0.308, OmegaL = 1 - OmegaM, ref, Dl_cm=NULL){
   #Assumed lux input is erg/s/cm^2/Ang (not per Hz!)
   if(!is.vector(wave)){
     if(dim(wave)[2]==2){
@@ -92,7 +94,9 @@ Flux2Lum=function(wave, flux, z = 0.1, H0 = 67.8, OmegaM = 0.308, OmegaL = 1 - O
       wave=wave[,1]
     }
   }
-  Dl_cm=cosdistLumDist(z=z, H0 = H0, OmegaM = OmegaM, OmegaL = OmegaL, ref=ref)*.mpc_to_cm
+  if(is.null(Dl_cm)){
+    Dl_cm=cosdistLumDist(z=z, H0 = H0, OmegaM = OmegaM, OmegaL = OmegaL, ref=ref)*.mpc_to_cm
+  }
   lum=flux/(.lsol_to_erg/(4*pi*Dl_cm^2)/(1+z))
   wave=wave/(1+z)
   #output is Lsol / Angstrom format

--- a/R/photom.R
+++ b/R/photom.R
@@ -67,7 +67,7 @@ Lum2FluxFactor=function(z = 0.1, H0 = 67.8, OmegaM = 0.308, OmegaL = 1 - OmegaM,
   return(factor)
 }
 
-Lum2Flux=function(wave, lum, z = 0.1, H0 = 67.8, OmegaM = 0.308, OmegaL = 1 - OmegaM, ref){
+Lum2Flux=function(wave, lum, z = 0.1, H0 = 67.8, OmegaM = 0.308, OmegaL = 1 - OmegaM, ref, Dl_cm=NULL){
   #Assumed lux input is Lsol / Angstrom
   if(!is.vector(wave)){
     if(dim(wave)[2]==2){
@@ -75,7 +75,9 @@ Lum2Flux=function(wave, lum, z = 0.1, H0 = 67.8, OmegaM = 0.308, OmegaL = 1 - Om
       wave=wave[,1]
     }
   }
-  Dl_cm=cosdistLumDist(z=z, H0 = H0, OmegaM = OmegaM, OmegaL = OmegaL, ref=ref)*.mpc_to_cm
+  if(is.null(Dl_cm)){
+    Dl_cm=cosdistLumDist(z=z, H0 = H0, OmegaM = OmegaM, OmegaL = OmegaL, ref=ref)*.mpc_to_cm
+  }
   flux=lum*.lsol_to_erg/(4*pi*Dl_cm^2)/(1+z)
   wave=wave*(1+z)
   #output is erg/s/cm^2/Ang (not per Hz! Need to make this final conversion to get to AB mag, but this is the standard way of viewing spectra).
@@ -140,7 +142,7 @@ photom_flux=function(wave, flux, outtype='mag', filters='all'){
   return(photom)
 }
 
-photom_lum=function(wave, lum, outtype='mag', filters='all', z = 0.1, H0 = 67.8, OmegaM = 0.308, OmegaL = 1 - OmegaM, ref){
+photom_lum=function(wave, lum, outtype='mag', filters='all', z = 0.1, H0 = 67.8, OmegaM = 0.308, OmegaL = 1 - OmegaM, ref, Dl_cm=NULL){
   
   if(!is.vector(wave)){
     if(dim(wave)[2]==2){
@@ -153,7 +155,7 @@ photom_lum=function(wave, lum, outtype='mag', filters='all', z = 0.1, H0 = 67.8,
     filters=list(filters)
   }
   
-  flux=Lum2Flux(wave=wave, lum=lum, z=z, H0=H0, OmegaM=OmegaM, OmegaL=OmegaL, ref=ref)
+  flux=Lum2Flux(wave=wave, lum=lum, z=z, H0=H0, OmegaM=OmegaM, OmegaL=OmegaL, ref=ref, Dl_cm=Dl_cm)
 
   if((filters=='all')[1]){
     cenwave=NULL

--- a/man/photom.Rd
+++ b/man/photom.Rd
@@ -15,10 +15,13 @@ These functions can manipulate restframe spectra in useful ways, e.g. placing it
 \usage{
 photom_flux(wave, flux, outtype = 'mag', filters = "all")
 photom_lum(wave, lum, outtype = 'mag', filters = "all", z = 0.1, H0 = 67.8,
-OmegaM = 0.308, OmegaL = 1 - OmegaM, ref)
-Lum2Flux(wave, lum, z = 0.1, H0 = 67.8, OmegaM = 0.308, OmegaL = 1 - OmegaM, ref)
-Flux2Lum(wave, flux, z = 0.1, H0 = 67.8, OmegaM = 0.308, OmegaL = 1 - OmegaM, ref)
-Lum2FluxFactor(z = 0.1, H0 = 67.8, OmegaM = 0.308, OmegaL = 1 - OmegaM, ref)
+OmegaM = 0.308, OmegaL = 1 - OmegaM, ref, Dl_cm = NULL)
+Lum2Flux(wave, lum, z = 0.1, H0 = 67.8, OmegaM = 0.308, OmegaL = 1 - OmegaM, ref,
+Dl_cm = NULL)
+Flux2Lum(wave, flux, z = 0.1, H0 = 67.8, OmegaM = 0.308, OmegaL = 1 - OmegaM, ref, 
+Dl_cm = NULL)
+Lum2FluxFactor(z = 0.1, H0 = 67.8, OmegaM = 0.308, OmegaL = 1 - OmegaM, ref, 
+Dl_cm = NULL)
 }
 %- maybe also 'usage' for other objects documented here.
 \arguments{
@@ -51,6 +54,9 @@ Numeric scalar; Omega Lambda today (default is for a flat Universe with OmegaL =
 }
   \item{ref}{
 The name of a reference cosmology to use, one of 137 / 737 / Planck / Planck13 / Planck15 / Planck18 / WMAP / WMAP9 / WMAP7 / WMAP5 / WMAP3 / WMAP1 / Millennium / GiggleZ. Planck = Planck18 and WMAP = WMAP9. The usage is case insensitive, so wmap9 is an allowed input. This overrides any other settings for H0, OmegaM and OmegaL. If OmegaR is missing from the reference set then it is inherited from the function input (0 by default). See \code{\link{cosref}} for details.
+  }
+  \item{Dl_cm}{
+Numeric scalar; Luminosity distance computed in units of cm. Default is NULL. The luminosity distance can be supplied for repeated computations when the redshift of the object is constant. 
   }
 }
 \details{


### PR DESCRIPTION
An example of how `photom_lum()` can be changed so that the celestial function `cosdistLumDist()` is not called if the luminosity distance in cm (`Dl_cm`) is supplied to the function. Requires modifications to the input of `Lum2Flux()` and `photom_lum()`. These changes could also be implemented in `Lum2FluxFactor()` and `Flux2Lum()`. Changes do not impact previous code as default `Dl_cm = NULL` - i.e. if `Dl_cm` is not supplied, the celestial function `cosdistLumDist()`will be run to calculate the value.