### PR TITLE
Faster cosmo

### DIFF
--- a/R/ProSpect.R
+++ b/R/ProSpect.R
@@ -593,8 +593,7 @@ ProSpectSEDlike = function(parm = c(8, 9, 10, 10, 0, -0.5, 0.2), Data) {
         }
       }
 
-      if(is.null(Data$cosmofast)){
-        if(is.null(Data$arglist$ref)){
+      if(is.null(Data$arglist$ref)){
           if(!is.null(z_genSF)){
             agemax_new = (celestial::cosdistUniAgeAtz(ztest, H0 = Data$arglist$HO, OmegaM = Data$arglist$OmegaM, OmegaL = Data$arglist$OmegaL) - 
             celestial::cosdistUniAgeAtz(z_genSF, H0 = Data$arglist$HO, OmegaM = Data$arglist$OmegaM, OmegaL = Data$arglist$OmegaL))*1e9 ##need to be in years
@@ -611,18 +610,7 @@ ProSpectSEDlike = function(parm = c(8, 9, 10, 10, 0, -0.5, 0.2), Data) {
           }
           LumDist_Mpc_new = celestial::cosdistLumDist(z = ztest, ref = Data$arglist$ref)
         }
-      }else if (is.function(Data$cosmofast$UniAgeAtz) & is.function(Data$cosmofast$LumDist)){
-        if(!is.null(z_genSF)){
-            agemax_new = (cosmofast$UniAgeAtz(ztest) - cosmofast$UniAgeAtz(z_genSF))*1e9 ##need to be in years
-          }else{
-            agemax_new = cosmofast$UniAgeAtz(ztest)
-          }
-        LumDist_Mpc_new = cosmofast$LumDist(ztest)
-      }else{
-        stop("Wrong self-defined cosmology tables")
-      }
       
-
       magemax_new = agemax_new/1e9 ## need to be in Gyr
       Zagemax_new = agemax_new/1e9
 

--- a/R/ProSpect.R
+++ b/R/ProSpect.R
@@ -593,19 +593,35 @@ ProSpectSEDlike = function(parm = c(8, 9, 10, 10, 0, -0.5, 0.2), Data) {
         }
       }
 
-      if(is.null(Data$arglist$ref)){
-        agemax_new = (celestial::cosdistUniAgeAtz(ztest, H0 = Data$arglist$HO, OmegaM = Data$arglist$OmegaM, OmegaL = Data$arglist$OmegaL))*1e9 ##need to be in years
-        if(!is.null(z_genSF)){
-          agemax_new = (celestial::cosdistUniAgeAtz(ztest, H0 = Data$arglist$HO, OmegaM = Data$arglist$OmegaM, OmegaL = Data$arglist$OmegaL) - celestial::cosdistUniAgeAtz(z_genSF, H0 = Data$arglist$HO, OmegaM = Data$arglist$OmegaM, OmegaL = Data$arglist$OmegaL))*1e9 ##need to be in years
+      if(is.null(Data$cosmofast)){
+        if(is.null(Data$arglist$ref)){
+          if(!is.null(z_genSF)){
+            agemax_new = (celestial::cosdistUniAgeAtz(ztest, H0 = Data$arglist$HO, OmegaM = Data$arglist$OmegaM, OmegaL = Data$arglist$OmegaL) - 
+            celestial::cosdistUniAgeAtz(z_genSF, H0 = Data$arglist$HO, OmegaM = Data$arglist$OmegaM, OmegaL = Data$arglist$OmegaL))*1e9 ##need to be in years
+          }else{
+            agemax_new = (celestial::cosdistUniAgeAtz(ztest, H0 = Data$arglist$HO, OmegaM = Data$arglist$OmegaM, OmegaL = Data$arglist$OmegaL))*1e9 ##need to be in years
+          }
+          LumDist_Mpc_new = celestial::cosdistLumDist(z = ztest, H0 = Data$arglist$HO, OmegaM = Data$arglist$OmegaM, OmegaL = Data$arglist$OmegaL)
+        }else{
+          if(!is.null(z_genSF)){
+            agemax_new = (celestial::cosdistUniAgeAtz(ztest, ref = Data$arglist$ref) - 
+            celestial::cosdistUniAgeAtz(z_genSF, ref = Data$arglist$ref))*1e9 ##need to be in years
+          }else{
+            agemax_new = (celestial::cosdistUniAgeAtz(ztest, ref = Data$arglist$ref))*1e9 ##need to be in years
+          }
+          LumDist_Mpc_new = celestial::cosdistLumDist(z = ztest, ref = Data$arglist$ref)
         }
-        LumDist_Mpc_new = celestial::cosdistLumDist(z = ztest, H0 = Data$arglist$HO, OmegaM = Data$arglist$OmegaM, OmegaL = Data$arglist$OmegaL)
+      }else if (is.function(Data$cosmofast$UniAgeAtz) & is.function(Data$cosmofast$LumDist)){
+        if(!is.null(z_genSF)){
+            agemax_new = (cosmofast$UniAgeAtz(ztest) - cosmofast$UniAgeAtz(z_genSF))*1e9 ##need to be in years
+          }else{
+            agemax_new = cosmofast$UniAgeAtz(ztest)
+          }
+        LumDist_Mpc_new = cosmofast$LumDist(ztest)
       }else{
-        agemax_new = (celestial::cosdistUniAgeAtz(ztest, ref = Data$arglist$ref))*1e9 ##need to be in years
-        if(!is.null(z_genSF)){
-          agemax_new = (celestial::cosdistUniAgeAtz(ztest, ref = Data$arglist$ref) - celestial::cosdistUniAgeAtz(z_genSF, ref = Data$arglist$ref))*1e9 ##need to be in years
-        }
-        LumDist_Mpc_new = celestial::cosdistLumDist(z = ztest, ref = Data$arglist$ref)
+        stop("Wrong self-defined cosmology tables")
       }
+      
 
       magemax_new = agemax_new/1e9 ## need to be in Gyr
       Zagemax_new = agemax_new/1e9


### PR DESCRIPTION
Doing fewer cosmology calculations in photoz fitting mode. Only compute `agemax` once if `z_genSF` is/isn't defined in `arglist` 